### PR TITLE
Add collaborative planner with user-specific and group sections

### DIFF
--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -77,6 +77,18 @@ export default function DayPlanner() {
 
   const dayKeys = Array.from({ length: Number(days) }, (_, i) => dateKeyLocal(addDays(selected, i)));
   const [editing, setEditing] = useState(null);
+
+  useEffect(() => {
+    if (!useCloud) return;
+    let mounted = true;
+    (async () => {
+      const data = await fetchPlannerRange(selected, days);
+      if (mounted && data) {
+        setPlanner(prev => ({ ...prev, ...data }));
+      }
+    })();
+    return () => { mounted = false; };
+  }, [useCloud, selected, days]);
   function addTodoFromSlot(dayKey, hour) {
     const slot = slotFor(dayKey, hour);
     const t = slot.text.trim();

--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -43,6 +43,9 @@ export default function DayPlanner() {
     const prev = slotFor(dayKey, hour);
     const nextDay = { ...getDaySlots(dayKey), [hour]: { text, done: prev.done, todoId: prev.todoId || null } };
     setPlanner({ ...planner, [dayKey]: nextDay });
+    if (useCloud) {
+      upsertSlotServer(dayKey, hour, { text, done: prev.done, todoId: prev.todoId || null });
+    }
     const t = text.trim();
     if (t && prev.todoId) {
       setTodos(todos.map(td => td.id === prev.todoId ? { ...td, text: t, updatedAt: Date.now() } : td));

--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -91,6 +91,9 @@ export default function DayPlanner() {
     const day = { ...getDaySlots(dayKey) };
     delete day[hour];
     setPlanner({ ...planner, [dayKey]: day });
+    if (useCloud) {
+      deleteSlotServer(dayKey, hour);
+    }
   }
 
   return (

--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -18,10 +18,15 @@ function addDays(d, delta) { const nd = new Date(d + 'T00:00:00'); nd.setDate(nd
 function labelFor(key) { const d = new Date(key + 'T00:00:00'); return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' }); }
 
 export default function DayPlanner() {
-  const [planner, setPlanner] = usePersistentState('planner', {});
+  const { user } = useAuth();
+  const [myPlanner, setMyPlanner] = usePersistentState('planner', {});
+  const [groupPlanner, setGroupPlanner] = useState({});
   const [selected, setSelected] = usePersistentState('planner:date', dateKeyLocal());
   const [days, setDays] = usePersistentState('planner:span', 5);
   const [todos, setTodos] = usePersistentState('todos', []);
+  const [groups, setGroups] = useState([]);
+  const [groupId, setGroupId] = useState('');
+  const [inviteInput, setInviteInput] = useState('');
   const supabase = getSupabase();
   const useCloud = !!supabase;
 

--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -108,6 +108,28 @@ export default function DayPlanner() {
     }
   }
 
+  useEffect(() => {
+    if (!useCloud) return;
+    const unsubscribe = subscribePlanner((payload) => {
+      const row = payload.new || payload.old;
+      const dayKey = row?.day;
+      const hour = row?.hour;
+      if (!dayKey || hour == null) return;
+      setPlanner(prev => {
+        const next = { ...prev };
+        const day = { ...(next[dayKey] || {}) };
+        if (payload.eventType === 'DELETE') {
+          delete day[hour];
+        } else {
+          day[hour] = { text: row.text || '', done: !!row.done, todoId: row.todo_id || null };
+        }
+        next[dayKey] = day;
+        return next;
+      });
+    });
+    return () => unsubscribe && unsubscribe();
+  }, [useCloud]);
+
   return (
     <div className="panel">
       <h3 className="panel-title">Plan Your Day</h3>

--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -96,22 +96,22 @@ export default function DayPlanner() {
     })();
     return () => { mounted = false; };
   }, [useCloud, selected, days]);
-  function addTodoFromSlot(dayKey, hour) {
-    const slot = slotFor(dayKey, hour);
+  function addTodoFromSlotGeneric(setMap, map, dayKey, hour) {
+    const slot = slotFor(map, dayKey, hour);
     const t = slot.text.trim();
     if (!t) return;
     if (slot.todoId) return;
-    createLinkedTodo(dayKey, hour, t, slot.done);
+    createLinkedTodo(setMap, map, dayKey, hour, t, slot.done);
   }
-  function deleteLinkedTodo(dayKey, hour) {
-    const slot = slotFor(dayKey, hour);
+  function deleteLinkedTodoGeneric(setMap, map, scope, dayKey, hour) {
+    const slot = slotFor(map, dayKey, hour);
     if (!slot.todoId) return;
     setTodos(todos.filter(td => td.id !== slot.todoId));
-    const day = { ...getDaySlots(dayKey) };
+    const day = { ...getDaySlots(map, dayKey) };
     delete day[hour];
-    setPlanner({ ...planner, [dayKey]: day });
-    if (useCloud) {
-      deleteSlotServer(dayKey, hour);
+    setMap({ ...map, [dayKey]: day });
+    if (useCloud && scope) {
+      deleteSlotServer(dayKey, hour, scope);
     }
   }
 

--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -85,17 +85,27 @@ export default function DayPlanner() {
   const dayKeys = Array.from({ length: Number(days) }, (_, i) => dateKeyLocal(addDays(selected, i)));
   const [editing, setEditing] = useState(null);
 
+  // Load my planner (user scope)
   useEffect(() => {
-    if (!useCloud) return;
+    if (!useCloud || !user?.id) return;
     let mounted = true;
     (async () => {
-      const data = await fetchPlannerRange(selected, days);
-      if (mounted && data) {
-        setPlanner(prev => ({ ...prev, ...data }));
-      }
+      const data = await fetchPlannerRange(selected, days, { type: 'user', id: user.id });
+      if (mounted && data) setMyPlanner(prev => ({ ...prev, ...data }));
     })();
     return () => { mounted = false; };
-  }, [useCloud, selected, days]);
+  }, [useCloud, user?.id, selected, days]);
+
+  // Load group planner (group scope)
+  useEffect(() => {
+    if (!useCloud || !groupId) return;
+    let mounted = true;
+    (async () => {
+      const data = await fetchPlannerRange(selected, days, { type: 'group', id: groupId });
+      if (mounted && data) setGroupPlanner(prev => ({ ...prev, ...data }));
+    })();
+    return () => { mounted = false; };
+  }, [useCloud, groupId, selected, days]);
   function addTodoFromSlotGeneric(setMap, map, dayKey, hour) {
     const slot = slotFor(map, dayKey, hour);
     const t = slot.text.trim();

--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { usePersistentState } from '../lib/hooks.js';
 import { getSupabase } from '../lib/supabaseClient.js';
 import { fetchPlannerRange, upsertSlot as upsertSlotServer, deleteSlot as deleteSlotServer, subscribePlanner } from '../lib/plannerApi.js';
+import { useAuth } from '../lib/AuthProvider.jsx';
+import { getMyGroups, createGroup, createInvite, acceptInvite } from '../lib/collabApi.js';
 
 function hoursRange(start = 6, end = 22) {
   const arr = [];

--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -125,27 +125,37 @@ export default function DayPlanner() {
     }
   }
 
+  // Realtime for my planner
   useEffect(() => {
-    if (!useCloud) return;
-    const unsubscribe = subscribePlanner((payload) => {
+    if (!useCloud || !user?.id) return;
+    const unsub = subscribePlanner((payload) => {
       const row = payload.new || payload.old;
-      const dayKey = row?.day;
-      const hour = row?.hour;
+      const dayKey = row?.day; const hour = row?.hour;
       if (!dayKey || hour == null) return;
-      setPlanner(prev => {
-        const next = { ...prev };
-        const day = { ...(next[dayKey] || {}) };
-        if (payload.eventType === 'DELETE') {
-          delete day[hour];
-        } else {
-          day[hour] = { text: row.text || '', done: !!row.done, todoId: row.todo_id || null };
-        }
-        next[dayKey] = day;
-        return next;
+      setMyPlanner(prev => {
+        const next = { ...prev }; const day = { ...(next[dayKey] || {}) };
+        if (payload.eventType === 'DELETE') delete day[hour]; else day[hour] = { text: row.text || '', done: !!row.done, todoId: row.todo_id || null };
+        next[dayKey] = day; return next;
       });
-    });
-    return () => unsubscribe && unsubscribe();
-  }, [useCloud]);
+    }, { type: 'user', id: user.id });
+    return () => unsub && unsub();
+  }, [useCloud, user?.id]);
+
+  // Realtime for group planner
+  useEffect(() => {
+    if (!useCloud || !groupId) return;
+    const unsub = subscribePlanner((payload) => {
+      const row = payload.new || payload.old;
+      const dayKey = row?.day; const hour = row?.hour;
+      if (!dayKey || hour == null) return;
+      setGroupPlanner(prev => {
+        const next = { ...prev }; const day = { ...(next[dayKey] || {}) };
+        if (payload.eventType === 'DELETE') delete day[hour]; else day[hour] = { text: row.text || '', done: !!row.done, todoId: row.todo_id || null };
+        next[dayKey] = day; return next;
+      });
+    }, { type: 'group', id: groupId });
+    return () => unsub && unsub();
+  }, [useCloud, groupId]);
 
   return (
     <div className="panel">

--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -82,6 +82,45 @@ export default function DayPlanner() {
 
   function onDateChange(e) { setSelected(e.target.value); }
 
+  // Load groups for current user
+  useEffect(() => {
+    if (!useCloud || !user?.id) return;
+    (async () => {
+      const gs = await getMyGroups();
+      setGroups(gs);
+      if (!groupId && gs.length) setGroupId(gs[0].id);
+    })();
+  }, [useCloud, user?.id]);
+
+  async function onCreateGroup() {
+    const name = prompt('Group name');
+    if (!name) return;
+    const g = await createGroup(name);
+    if (g) { const gs = await getMyGroups(); setGroups(gs); setGroupId(g.id); }
+  }
+
+  async function onInviteLink() {
+    if (!groupId) return;
+    const token = await createInvite(groupId);
+    if (token) {
+      const url = `${window.location.origin}#invite=${token}`;
+      try { await navigator.clipboard.writeText(url); alert('Invite link copied to clipboard'); } catch { alert(url); }
+    }
+  }
+
+  async function onAcceptInvite() {
+    const token = inviteInput.trim();
+    if (!token) return;
+    const res = await acceptInvite(token);
+    if (res.ok) {
+      const gs = await getMyGroups(); setGroups(gs);
+      setGroupId(res.group_id);
+      setInviteInput('');
+    } else {
+      alert('Invalid or expired invite');
+    }
+  }
+
   const dayKeys = Array.from({ length: Number(days) }, (_, i) => dateKeyLocal(addDays(selected, i)));
   const [editing, setEditing] = useState(null);
 

--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -20,6 +20,8 @@ export default function DayPlanner() {
   const [selected, setSelected] = usePersistentState('planner:date', dateKeyLocal());
   const [days, setDays] = usePersistentState('planner:span', 5);
   const [todos, setTodos] = usePersistentState('todos', []);
+  const supabase = getSupabase();
+  const useCloud = !!supabase;
 
   function getDaySlots(dayKey) { return planner[dayKey] || {}; }
   function slotFor(dayKey, hour) {

--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -1,5 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { usePersistentState } from '../lib/hooks.js';
+import { getSupabase } from '../lib/supabaseClient.js';
+import { fetchPlannerRange, upsertSlot as upsertSlotServer, deleteSlot as deleteSlotServer, subscribePlanner } from '../lib/plannerApi.js';
 
 function hoursRange(start = 6, end = 22) {
   const arr = [];

--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -249,16 +249,16 @@ export default function DayPlanner() {
       </div>
 
       <div className="panel">
-        <div className="row between wrap" style={{ marginBottom: 12 }}>
+        <div className="row between wrap section-gap">
           <h3 className="panel-title">Shared Planner</h3>
-          <div className="row wrap" style={{ gap: 8 }}>
-            <select className="select" value={groupId} onChange={e => setGroupId(e.target.value)} style={{ minWidth: 160 }}>
+          <div className="row wrap">
+            <select className="select collab-select" value={groupId} onChange={e => setGroupId(e.target.value)}>
               <option value="">Select group</option>
               {groups.map(g => <option key={g.id} value={g.id}>{g.name}</option>)}
             </select>
             <button className="btn secondary" onClick={onCreateGroup}>Create group</button>
             <button className="btn secondary" onClick={onInviteLink} disabled={!groupId}>Invite link</button>
-            <input className="input" placeholder="Paste invite token" value={inviteInput} onChange={e => setInviteInput(e.target.value)} style={{ maxWidth: 220 }} />
+            <input className="input invite-input" placeholder="Paste invite token" value={inviteInput} onChange={e => setInviteInput(e.target.value)} />
             <button className="btn" onClick={onAcceptInvite}>Join</button>
           </div>
         </div>

--- a/src/components/DayPlanner.jsx
+++ b/src/components/DayPlanner.jsx
@@ -56,6 +56,9 @@ export default function DayPlanner() {
     const prev = slotFor(dayKey, hour);
     const nextDay = { ...getDaySlots(dayKey), [hour]: { text: prev.text, done, todoId: prev.todoId || null } };
     setPlanner({ ...planner, [dayKey]: nextDay });
+    if (useCloud) {
+      upsertSlotServer(dayKey, hour, { text: prev.text, done, todoId: prev.todoId || null });
+    }
     if (prev.todoId) {
       setTodos(todos.map(td => td.id === prev.todoId ? { ...td, done, updatedAt: Date.now() } : td));
     } else if (prev.text && prev.text.trim()) {

--- a/src/lib/collabApi.js
+++ b/src/lib/collabApi.js
@@ -1,0 +1,62 @@
+import { getSupabase } from './supabaseClient.js';
+
+export async function getCurrentUser() {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+  const { data } = await supabase.auth.getUser();
+  return data.user || null;
+}
+
+export async function getMyGroups() {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+  const user = await getCurrentUser();
+  if (!user) return [];
+  const { data, error } = await supabase
+    .from('group_members')
+    .select('group_id, groups(id, name)')
+    .eq('user_id', user.id);
+  if (error) return [];
+  return (data || []).map(r => ({ id: r.groups?.id || r.group_id, name: r.groups?.name || 'Group' }));
+}
+
+export async function createGroup(name) {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+  const user = await getCurrentUser();
+  if (!user) return null;
+  const { data: g, error } = await supabase.from('groups').insert({ name, owner_id: user.id }).select('*').single();
+  if (error) return null;
+  await supabase.from('group_members').insert({ group_id: g.id, user_id: user.id, role: 'owner' });
+  return g;
+}
+
+export async function createInvite(groupId, ttlHours = 168) {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+  const user = await getCurrentUser();
+  if (!user) return null;
+  const expires = new Date(Date.now() + ttlHours * 3600 * 1000).toISOString();
+  const token = crypto.randomUUID();
+  const payload = { token, group_id: groupId, created_by: user.id, expires_at: expires };
+  const { error } = await supabase.from('group_invites').insert(payload);
+  if (error) return null;
+  return token;
+}
+
+export async function acceptInvite(token) {
+  const supabase = getSupabase();
+  if (!supabase) return { ok: false, reason: 'no_supabase' };
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, reason: 'no_user' };
+  const { data: inv, error } = await supabase
+    .from('group_invites')
+    .select('*')
+    .eq('token', token)
+    .gt('expires_at', new Date().toISOString())
+    .limit(1)
+    .single();
+  if (error || !inv) return { ok: false, reason: 'invalid_token' };
+  await supabase.from('group_members').upsert({ group_id: inv.group_id, user_id: user.id, role: 'member' }, { onConflict: 'group_id,user_id' });
+  return { ok: true, group_id: inv.group_id };
+}

--- a/src/lib/plannerApi.js
+++ b/src/lib/plannerApi.js
@@ -4,7 +4,12 @@ function normalizeRow(row) {
   return { text: row.text || '', done: !!row.done, todoId: row.todo_id || null };
 }
 
-export async function fetchPlannerRange(startKey, days) {
+function scopeFilter(query, scope) {
+  if (!scope || !scope.type || !scope.id) return query;
+  return query.eq('owner_type', scope.type).eq('owner_id', scope.id);
+}
+
+export async function fetchPlannerRange(startKey, days, scope) {
   const supabase = getSupabase();
   if (!supabase) return null;
   try {
@@ -13,11 +18,13 @@ export async function fetchPlannerRange(startKey, days) {
     end.setDate(end.getDate() + Number(days) - 1);
     const startIso = start.toISOString().slice(0, 10);
     const endIso = end.toISOString().slice(0, 10);
-    const { data, error } = await supabase
+    let query = supabase
       .from('planner_slots')
       .select('*')
       .gte('day', startIso)
-      .lte('day', endIso)
+      .lte('day', endIso);
+    query = scopeFilter(query, scope);
+    const { data, error } = await query
       .order('day', { ascending: true })
       .order('hour', { ascending: true });
     if (error) return null;
@@ -33,7 +40,7 @@ export async function fetchPlannerRange(startKey, days) {
   }
 }
 
-export async function upsertSlot(dayKey, hour, values) {
+export async function upsertSlot(dayKey, hour, values, scope) {
   const supabase = getSupabase();
   if (!supabase) return;
   const payload = {
@@ -42,27 +49,30 @@ export async function upsertSlot(dayKey, hour, values) {
     text: values.text || '',
     done: !!values.done,
     todo_id: values.todoId || null,
+    owner_type: scope?.type || null,
+    owner_id: scope?.id || null,
   };
-  await supabase.from('planner_slots').upsert(payload, { onConflict: 'day,hour' });
+  await supabase.from('planner_slots').upsert(payload, { onConflict: 'day,hour,owner_type,owner_id' });
 }
 
-export async function deleteSlot(dayKey, hour) {
+export async function deleteSlot(dayKey, hour, scope) {
   const supabase = getSupabase();
   if (!supabase) return;
-  await supabase.from('planner_slots').delete().eq('day', dayKey).eq('hour', hour);
+  let q = supabase.from('planner_slots').delete().eq('day', dayKey).eq('hour', hour);
+  if (scope && scope.type && scope.id) { q = q.eq('owner_type', scope.type).eq('owner_id', scope.id); }
+  await q;
 }
 
-export function subscribePlanner(onChange) {
+export function subscribePlanner(onChange, scope) {
   const supabase = getSupabase();
   if (!supabase) return () => {};
+  const filter = scope && scope.type && scope.id ? `owner_type=eq.${scope.type},owner_id=eq.${scope.id}` : undefined;
   const channel = supabase
     .channel('planner-slots')
     .on(
       'postgres_changes',
-      { event: '*', schema: 'public', table: 'planner_slots' },
-      (payload) => {
-        onChange(payload);
-      }
+      { event: '*', schema: 'public', table: 'planner_slots', filter },
+      (payload) => { onChange(payload); }
     )
     .subscribe();
   return () => {

--- a/src/lib/plannerApi.js
+++ b/src/lib/plannerApi.js
@@ -1,0 +1,71 @@
+import { getSupabase } from './supabaseClient.js';
+
+function normalizeRow(row) {
+  return { text: row.text || '', done: !!row.done, todoId: row.todo_id || null };
+}
+
+export async function fetchPlannerRange(startKey, days) {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+  try {
+    const start = new Date(startKey + 'T00:00:00');
+    const end = new Date(start);
+    end.setDate(end.getDate() + Number(days) - 1);
+    const startIso = start.toISOString().slice(0, 10);
+    const endIso = end.toISOString().slice(0, 10);
+    const { data, error } = await supabase
+      .from('planner_slots')
+      .select('*')
+      .gte('day', startIso)
+      .lte('day', endIso)
+      .order('day', { ascending: true })
+      .order('hour', { ascending: true });
+    if (error) return null;
+    const map = {};
+    for (const r of data) {
+      const k = r.day; // already YYYY-MM-DD
+      if (!map[k]) map[k] = {};
+      map[k][r.hour] = normalizeRow(r);
+    }
+    return map;
+  } catch {
+    return null;
+  }
+}
+
+export async function upsertSlot(dayKey, hour, values) {
+  const supabase = getSupabase();
+  if (!supabase) return;
+  const payload = {
+    day: dayKey,
+    hour,
+    text: values.text || '',
+    done: !!values.done,
+    todo_id: values.todoId || null,
+  };
+  await supabase.from('planner_slots').upsert(payload, { onConflict: 'day,hour' });
+}
+
+export async function deleteSlot(dayKey, hour) {
+  const supabase = getSupabase();
+  if (!supabase) return;
+  await supabase.from('planner_slots').delete().eq('day', dayKey).eq('hour', hour);
+}
+
+export function subscribePlanner(onChange) {
+  const supabase = getSupabase();
+  if (!supabase) return () => {};
+  const channel = supabase
+    .channel('planner-slots')
+    .on(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: 'planner_slots' },
+      (payload) => {
+        onChange(payload);
+      }
+    )
+    .subscribe();
+  return () => {
+    try { supabase.removeChannel(channel); } catch {}
+  };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -246,7 +246,7 @@ html[data-theme="dark"] .palette-item:hover { background: rgba(255,255,255,.06);
 .mode-btn.long-variant.active { background: var(--accent-purple); border-color: var(--accent-purple); }
 
 /* Dark mode adjustments for focus accents */
-hofml[data-theme="dark"] .focus-accent { background: linear-gradient(180deg, rgba(147,197,253,.16), transparent 60%), var(--panel); }
+html[data-theme="dark"] .focus-accent { background: linear-gradient(180deg, rgba(147,197,253,.16), transparent 60%), var(--panel); }
 html[data-theme="dark"] .timer-ring { filter: drop-shadow(0 8px 22px rgba(147,197,253,.18)); }
 html[data-theme="dark"] .mode-btn.short-variant.active { background: #facc15; border-color: #facc15; color: #231a00; }
 html[data-theme="dark"] .mode-btn.long-variant.active { background: #c4b5fd; border-color: #c4b5fd; color: #0b0f1a; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -296,6 +296,11 @@ html[data-theme="dark"] .accent-purple { color: #c4b5fd; }
 /* Date input */
 .date-input { max-width: 180px; }
 
+/* Collaboration UI utilities */
+.section-gap { margin-bottom: 12px; }
+.collab-select { min-width: 160px; }
+.invite-input { max-width: 220px; }
+
 /* Dark mode: improve native dropdown/options and calendar icon visibility */
 html[data-theme="dark"] .select,
 html[data-theme="dark"] select { background-color: rgba(255,255,255,.06); color: var(--text); border-color: var(--border); color-scheme: dark; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -296,6 +296,19 @@ html[data-theme="dark"] .accent-purple { color: #c4b5fd; }
 /* Date input */
 .date-input { max-width: 180px; }
 
+/* Dark mode: improve native dropdown/options and calendar icon visibility */
+html[data-theme="dark"] .select,
+html[data-theme="dark"] select { background-color: rgba(255,255,255,.06); color: var(--text); border-color: var(--border); color-scheme: dark; }
+html[data-theme="dark"] select option,
+html[data-theme="dark"] select optgroup { background: var(--panel); color: var(--text); }
+html[data-theme="dark"] select:focus { outline: none; box-shadow: 0 0 0 2px color-mix(in oklab, var(--primary) 45%, transparent); }
+
+html[data-theme="dark"] .input.date-input,
+html[data-theme="dark"] input[type="date"] { background-color: rgba(255,255,255,.06); color: var(--text); border-color: var(--border); color-scheme: dark; }
+html[data-theme="dark"] input[type="date"]::-webkit-calendar-picker-indicator { filter: invert(1) brightness(1.25) contrast(1.1); opacity: .95; }
+html[data-theme="dark"] input[type="date"]::-webkit-inner-spin-button,
+html[data-theme="dark"] input[type="date"]::-webkit-clear-button { filter: invert(1) brightness(1.2); }
+
 /* Tasks: enhancements */
 .item-left-expand { flex: 1; }
 .task-active { background: var(--panel); }

--- a/src/styles.css
+++ b/src/styles.css
@@ -117,6 +117,14 @@ html[data-theme="dark"] .planner-done .planner-cell { background: color-mix(in o
 .input, .select, .textarea { width: 100%; padding: 10px 12px; border: 1px solid var(--border); background: transparent; color: var(--text); border-radius: 10px; }
 .textarea { min-height: 120px; resize: vertical; }
 
+/* Improve native control contrast in dark mode without changing shape/colors */
+@supports (color-scheme: light) {
+  html { color-scheme: light; }
+  html[data-theme="dark"] { color-scheme: dark; }
+}
+html[data-theme="dark"] input, html[data-theme="dark"] select, html[data-theme="dark"] textarea { background-color: rgba(255,255,255,.03); }
+html[data-theme="dark"] input[type="date"]::-webkit-calendar-picker-indicator { filter: invert(1) brightness(1.1) contrast(1.1); }
+
 .row { display: flex; gap: 8px; align-items: center; }
 .row.wrap { flex-wrap: wrap; }
 .row.between { justify-content: space-between; }
@@ -238,7 +246,7 @@ html[data-theme="dark"] .palette-item:hover { background: rgba(255,255,255,.06);
 .mode-btn.long-variant.active { background: var(--accent-purple); border-color: var(--accent-purple); }
 
 /* Dark mode adjustments for focus accents */
-html[data-theme="dark"] .focus-accent { background: linear-gradient(180deg, rgba(147,197,253,.16), transparent 60%), var(--panel); }
+hofml[data-theme="dark"] .focus-accent { background: linear-gradient(180deg, rgba(147,197,253,.16), transparent 60%), var(--panel); }
 html[data-theme="dark"] .timer-ring { filter: drop-shadow(0 8px 22px rgba(147,197,253,.18)); }
 html[data-theme="dark"] .mode-btn.short-variant.active { background: #facc15; border-color: #facc15; color: #231a00; }
 html[data-theme="dark"] .mode-btn.long-variant.active { background: #c4b5fd; border-color: #c4b5fd; color: #0b0f1a; }


### PR DESCRIPTION
## Purpose

Implement a collaborative planner system where users can have both personal and shared planning spaces. Users who collaborate through invite links share a common group planner, while maintaining their own individual timetables displayed in separate sections of the page.

## Code changes

- **Split planner state**: Added separate `myPlanner` (personal) and `groupPlanner` (shared) state management
- **Collaboration API**: Created `collabApi.js` with functions for group management, invite creation/acceptance, and user authentication
- **Planner API**: Added `plannerApi.js` for cloud-based planner data with real-time synchronization via Supabase
- **Dual planner UI**: Modified DayPlanner component to display both personal and group planners in separate sections
- **Real-time updates**: Implemented live synchronization for both personal and group planner changes
- **Invite system**: Added UI controls for creating groups, generating invite links, and accepting invitations
- **Scoped data**: All planner operations now support user-scoped and group-scoped data storage
- **Enhanced styling**: Improved dark mode support for form controls and added collaboration-specific CSS classesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3aaa6065110f477887a748ad23872a63/mystic-studio)

👀 [Preview Link](https://3aaa6065110f477887a748ad23872a63-mystic-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3aaa6065110f477887a748ad23872a63</projectId>-->
<!--<branchName>mystic-studio</branchName>-->